### PR TITLE
Adds config `server.settings.pid_file`

### DIFF
--- a/config/autoload/server.php
+++ b/config/autoload/server.php
@@ -25,4 +25,7 @@ return [
             ],
         ],
     ],
+    'settings' => [
+        'pid_file' => BASE_PATH . '/runtime/hyperf.pid',
+    ]
 ];


### PR DESCRIPTION
Fix the exception that can not found pid_file when running in `server:watch`